### PR TITLE
add flow for into_bytes if Content-Length header is missing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.3.17"
 default-features = false
 
 [dependencies.async-stream]
-version = "0.3.2"
+version = "= 0.3.2"
 optional = true
 
 [dependencies.chrono]

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,12 +9,16 @@ pub fn is_default<T: Default + PartialEq>(t: &T) -> bool {
 }
 
 fn into_bytes(response: ureq::Response) -> Result<Vec<u8>, ParseError> {
-    let len = response
+    let mut bytes = if response.has("Content-Length") {
+        let len = response
         .header("Content-Length")
         .and_then(|s| s.parse::<usize>().ok())
         .ok_or(ParseError::MissingHeader("Content-Length"))?;
 
-    let mut bytes: Vec<u8> = Vec::with_capacity(len);
+        Vec::with_capacity(len)
+    } else {
+        vec![]
+    };
 
     match response.into_reader().read_to_end(&mut bytes) {
         Ok(_) => Ok(bytes),


### PR DESCRIPTION
Holodex API does not return Content-Length header but instead Transfer-Encoding chunked. Added a flow for missing Content-Length header to parse the response.